### PR TITLE
Update events API from v1beta1 to v1

### DIFF
--- a/app/pyfiles/trexevent.py
+++ b/app/pyfiles/trexevent.py
@@ -58,7 +58,8 @@ def create_event(data):
             'type': 'Normal',
             'eventTime': evtTimeMicro,
             'series': {
-                'lastObservedTime': evtTime
+                'lastObservedTime': evtTime,
+                'count': 2
             },
             'reason': data['reason'],
             'action': data['reason'],

--- a/app/pyfiles/trexevent.py
+++ b/app/pyfiles/trexevent.py
@@ -1,6 +1,6 @@
 import random
 import string
-from kubernetes import client, config, watch
+from kubernetes import client, config
 from kubernetes.client.rest import ApiException
 from kubernetes.config.config_exception import ConfigException
 
@@ -48,7 +48,7 @@ def create_event(data):
     evtName = trex_config_name + '-' + ''.join(random.choices(string.ascii_lowercase + string.digits, k=6))
 
     cr = {
-            'apiVersion': 'events.k8s.io/v1beta1',
+            'apiVersion': 'events.k8s.io/v1',
             'kind': 'Event',
             'metadata': {
                'name': evtName,
@@ -57,8 +57,9 @@ def create_event(data):
             },
             'type': 'Normal',
             'eventTime': evtTimeMicro,
-            'deprecatedLastTimestamp': evtTime,
-            'deprecatedFirstTimestamp': evtTime,
+            'series': {
+                'lastObservedTime': evtTime
+            },
             'reason': data['reason'],
             'action': data['reason'],
             'note': data['msg'],
@@ -80,7 +81,9 @@ def create_event(data):
             'controller': True
         })
 
-    events_api = client.EventsV1beta1Api()
+    log.info("CR to be used for the event creation: {}".format(cr))
+
+    events_api = client.EventsV1Api()
     try:
         resp = events_api.create_namespaced_event(namespace, cr)
     except ApiException as e:

--- a/build.sh
+++ b/build.sh
@@ -18,7 +18,7 @@ if [[ "$1" == "-h" ]] ; then
     exit 0
 fi
 
-TAG="${TAG:-v0.2.4}"
+TAG="${TAG:-v0.2.6}"
 
 CLI=${CLI:="podman"}
 ORG=${ORG:="rh-nfv-int"}

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,23 @@
 
 set -e
 
-TAG="${TAG:-v0.2.2}"
+if [[ "$1" == "-h" ]] ; then
+    echo "A tool that allows you to build TRex application containers."
+    echo
+    echo "Usage:"
+    echo "    `basename $0` [list of containers to build] [extra options]"
+    echo
+    echo "List of containers to build:"
+    echo "    all: build two containers: server and app"
+    echo "    app: build app container"
+    echo "    server: build server container"
+    echo
+    echo "Extra options:"
+    echo "    force: use --no-cache for the image build"
+    exit 0
+fi
+
+TAG="${TAG:-v0.2.4}"
 
 CLI=${CLI:="podman"}
 ORG=${ORG:="rh-nfv-int"}


### PR DESCRIPTION
We have the following error during the tests on OCP-4.12:
```
Exception on creating Event: (404)\nReason: 
Not Found\nHTTP response headers: 
HTTPHeaderDict({'Audit-Id': 'd15af9d8-e321-4b6a-b3d1-c87982a149b0', 
'Cache-Control': 'no-cache, private', 'Content-Type': 'application/json', 
'X-Kubernetes-Pf-Flowschema-Uid': '66546c3f-d66e-4618-8504-49d1a6760218', 
'X-Kubernetes-Pf-Prioritylevel-Uid': '4f8abc92-b8e0-4877-aec3-3cce85e84143', 
'Date': 'Fri, 14 Oct 2022 15:25:26 GMT', 'Content-Length': '174'})\n
HTTP response body: {\"kind\":\"Status\",\"apiVersion\":\"v1\",\
"metadata\":{},\"status\":\"Failure\",\"message\":
\"the server could not find the requested resource\",\"reason\":
\"NotFound\",\"details\":{},\"code\":404 
```

The earlier OCP versions work fine. 
It seems like the error is happening because trex-container-app uses **events.k8s.io/v1beta1** deprecated in k8s 1.25 (OCP 4.12): https://kubernetes.io/docs/reference/using-api/deprecation-guide/#event-v125 
