### PR TITLE
Add GitHub Action to build images on PRs

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,40 @@
+name: Pull Request image
+
+on:
+  pull_request:
+    branches:
+      - master
+
+  workflow_dispatch:
+    inputs:
+      force_build:
+        description: "Force building images from a branch"
+        required: true
+        default: false
+        type: boolean
+
+env:
+  REGISTRY: quay.io
+
+jobs:
+  pull-request-image:
+    # Build only when the PR comes from a branch in the same repo or forced
+    if: github.repository == github.event.pull_request.head.repo.full_name || inputs.force_build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to Quay.io
+        uses: redhat-actions/podman-login@v1
+        with:
+          username: ${{ secrets.QUAY_USER }}
+          password: ${{ secrets.QUAY_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+
+      - name: Build and Push the images
+        run: |
+          ORG=${GITHUB_REPOSITORY%/*}
+          SHA=$(git rev-parse --short HEAD)
+          make all ORG=${ORG} TAG=${SHA}


### PR DESCRIPTION
Building images on PRs will help to ease the testing of such images
The images pushed use the commit hash as the tag.

Only PRs coming from the same repo will trigger the build+push of images.

It's possible to manually force a build+push of images in a branch (without a PR) through a dispatch workflow using a branch in the repo.

This is identical to https://github.com/rh-nfv-int/testpmd-container-app/pull/5, the main difference is that this PR comes from a branch in the **same repo**, so the _base repo_ and the _head repo_ are the same, thus this will trigger a build+push of the images.

Please take a look to https://github.com/rh-nfv-int/testpmd-container-app/pull/5  for the testing details